### PR TITLE
make bigint great again : patched with modern Nan bindings 

### DIFF
--- a/bigint.cc
+++ b/bigint.cc
@@ -238,12 +238,11 @@ NAN_METHOD(BigInt::New)
     return;
   }
 
-  //HandleScope scope;
+  Nan::HandleScope scope;
   BigInt *bigint;
   uint64_t base;
 
   if(info[0]->IsExternal()) {
-    //mpz_t *num = (mpz_t *) External::Unwrap(args[0]);
     mpz_t *num =  static_cast<mpz_t *>(External::Cast(*(info[0]))->Value());
 
     bigint = new BigInt(num);
@@ -327,7 +326,7 @@ NAN_METHOD(BigInt::Bsub)
 NAN_METHOD(BigInt::Bmul)
 {
   BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
-  //HandleScope scope;
+  Nan::HandleScope scope;
 
   BigInt *bi = Nan::ObjectWrap::Unwrap<BigInt>(info[0]->ToObject());
   mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
@@ -341,7 +340,7 @@ NAN_METHOD(BigInt::Bmul)
 NAN_METHOD(BigInt::Bdiv)
 {
   BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
-  //HandleScope scope;
+  Nan::HandleScope scope;
 
   BigInt *bi = Nan::ObjectWrap::Unwrap<BigInt>(info[0]->ToObject());
   mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
@@ -355,7 +354,7 @@ NAN_METHOD(BigInt::Bdiv)
 NAN_METHOD(BigInt::Uadd)
 {
   BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
-//  HandleScope scope;
+  Nan::HandleScope scope;
 
   REQ_UINT64_ARG(0, x);
   mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
@@ -370,7 +369,7 @@ NAN_METHOD(BigInt::Uadd)
 NAN_METHOD(BigInt::Usub)
 {
   BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
-//  HandleScope scope;
+  Nan::HandleScope scope;
 
   REQ_UINT64_ARG(0, x);
   mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
@@ -384,7 +383,7 @@ NAN_METHOD(BigInt::Usub)
 NAN_METHOD(BigInt::Umul)
 {
   BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
-  //HandleScope scope;
+  Nan::HandleScope scope;
 
   REQ_UINT64_ARG(0, x);
   mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
@@ -398,7 +397,7 @@ NAN_METHOD(BigInt::Umul)
 NAN_METHOD(BigInt::Udiv)
 {
   BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
-//  HandleScope scope;
+  Nan::HandleScope scope;
 
   REQ_UINT64_ARG(0, x);
   mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
@@ -412,7 +411,7 @@ NAN_METHOD(BigInt::Udiv)
 NAN_METHOD(BigInt::Umul_2exp)
 {
   BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
-//  HandleScope scope;
+  Nan::HandleScope scope;
 
   REQ_UINT64_ARG(0, x);
   mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
@@ -426,7 +425,7 @@ NAN_METHOD(BigInt::Umul_2exp)
 NAN_METHOD(BigInt::Udiv_2exp)
 {
   BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
-//  HandleScope scope;
+  Nan::HandleScope scope;
 
   REQ_UINT64_ARG(0, x);
   mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
@@ -712,7 +711,7 @@ NAN_METHOD(BigInt::Bgcd)
 static NAN_METHOD(SetJSConditioner)
 {
   BigInt::SetJSConditioner(Local<Function>::Cast(info[0]));
-  return; // Undefined();
+  return;
 }
 
 extern "C" void

--- a/bigint.cc
+++ b/bigint.cc
@@ -7,8 +7,7 @@
 #include <iostream>
 
 #include <nan.h>
-//#include <v8.h>
-//#include <node.h>
+
 #include <gmp.h>
 #include <map>
 #include <utility>
@@ -71,10 +70,6 @@ using namespace std;
   Local<Value> arg[1] = { Nan::New<External>(static_cast<mpz_t *>(RES)) };  \
   Local<Object> VAR = Nan::New<FunctionTemplate>(constructor_template)->      \
     GetFunction()->NewInstance(1, arg);
-//
-// #define WRAP_RESULT(RES, VAR)							\
-//   Handle<Value> arg[1] = { External::New(*RES) };				\
-//   Local<Object> VAR = tmpl->GetFunction()->NewInstance(1, arg);
 
 class BigInt : public Nan::ObjectWrap {
   public:

--- a/bigint.cc
+++ b/bigint.cc
@@ -114,8 +114,8 @@ class BigInt : public Nan::ObjectWrap {
     static NAN_METHOD(Upow);
     static NAN_METHOD(Uupow);
     static NAN_METHOD(Brand0);
-    static NAN_METHOD(Uprime0);
     static NAN_METHOD(Probprime);
+    static NAN_METHOD(Nextprime);
     static NAN_METHOD(Bcompare);
     static NAN_METHOD(Scompare);
     static NAN_METHOD(Ucompare);
@@ -148,8 +148,6 @@ void BigInt::Initialize(v8::Local<v8::Object> target) {
   tmpl->InstanceTemplate()->SetInternalFieldCount(1);
   tmpl->SetClassName(Nan::New("BigInt").ToLocalChecked());
 
-  Nan::SetMethod(tmpl, "uprime0", Uprime0);
-
   Nan::SetPrototypeMethod(tmpl, "toString", ToString);
   Nan::SetPrototypeMethod(tmpl, "badd", Badd);
   Nan::SetPrototypeMethod(tmpl, "bsub", Bsub);
@@ -171,7 +169,7 @@ void BigInt::Initialize(v8::Local<v8::Object> target) {
   Nan::SetPrototypeMethod(tmpl, "uupow", Uupow);
   Nan::SetPrototypeMethod(tmpl, "brand0", Brand0);
   Nan::SetPrototypeMethod(tmpl, "probprime", Probprime);
-//  Nan::SetPrototypeMethod(tmpl, "nextprime", Nextprime);
+  Nan::SetPrototypeMethod(tmpl, "nextprime", Nextprime);
   Nan::SetPrototypeMethod(tmpl, "bcompare", Bcompare);
   Nan::SetPrototypeMethod(tmpl, "scompare", Scompare);
   Nan::SetPrototypeMethod(tmpl, "ucompare", Ucompare);
@@ -582,19 +580,18 @@ NAN_METHOD(BigInt::Probprime)
   info.GetReturnValue().Set(Nan::New<Number>(mpz_probab_prime_p(*bigint->bigint_, reps)));
 }
 
-// NAN_METHOD(BigInt::Nextprime)
-// {
-//   BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
-//
-//   mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
-//   mpz_init(*res);
-//   mpz_nextprime(*res, *bigint->bigint_);
-//
-//   WRAP_RESULT(res, result);
-//
-//   info.GetReturnValue().Set(result);
-// }
+NAN_METHOD(BigInt::Nextprime)
+{
+  BigInt *bigint = Nan::ObjectWrap::Unwrap<BigInt>(info.This());
 
+  mpz_t *res = (mpz_t *) malloc(sizeof(mpz_t));
+  mpz_init(*res);
+  mpz_nextprime(*res, *bigint->bigint_);
+
+  WRAP_RESULT(res, result);
+
+  info.GetReturnValue().Set(result);
+}
 
 NAN_METHOD(BigInt::Bcompare)
 {

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,9 @@
     {
       'target_name': 'bigint',
       'sources': [ 'bigint.cc' ],
+      'include_dirs': [
+        "<!(node -e \"require('nan')\")"
+      ],
       'conditions': [
         ['OS=="linux"',
           {

--- a/package.json
+++ b/package.json
@@ -1,37 +1,40 @@
 {
-    "name" : "bigint",
-    "version" : "0.4.2",
-    "description" : "Arbitrary-precision integer arithmetic using libgmp",
-    "main" : "./index.js",
-    "repository" : {
-        "type" : "git",
-        "url" : "http://github.com/substack/node-bigint.git"
-    },
-    "keywords": [
-        "gmp",
-        "libgmp",
-        "big",
-        "bignum",
-        "bigint",
-        "integer",
-        "arithmetic",
-        "precision"
-    ],
-    "author" : {
-        "name" : "James Halliday",
-        "email" : "mail@substack.net",
-        "url" : "http://substack.net"
-    },
-    "devDependencies" : {
-        "tap" : "~0.2.5",
-        "put" : "~0.0.6"
-    },
-    "license" : "MIT/X11",
-    "engine" : {
-        "node" : ">=0.2.0"
-    },
-    "scripts" : {
-        "install" : "node-gyp configure build",
-        "test" : "tap test/*.js"
-    }
+  "name": "bigint",
+  "version": "0.4.2",
+  "description": "Arbitrary-precision integer arithmetic using libgmp",
+  "main": "./index.js",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/substack/node-bigint.git"
+  },
+  "keywords": [
+    "gmp",
+    "libgmp",
+    "big",
+    "bignum",
+    "bigint",
+    "integer",
+    "arithmetic",
+    "precision"
+  ],
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "devDependencies": {
+    "tap": "~0.2.5",
+    "put": "~0.0.6"
+  },
+  "license": "MIT/X11",
+  "engine": {
+    "node": ">=0.2.0"
+  },
+  "scripts": {
+    "install": "node-gyp configure build",
+    "test": "tap test/*.js"
+  },
+  "dependencies": {
+    "nan": "^2.2.1"
+  }
 }

--- a/test/root.js
+++ b/test/root.js
@@ -1,11 +1,11 @@
-var test = require('tap').test;
-var bigint = require('../');
+var test = require('tap').test
+var bigint = require('../')
 
 test('sqrt and root', function (t) {
-    var r = bigint(32769)
-	var sqrt = r.sqrt()
-	var root = r.root(2)
-	t.same(root.toString(), '181')
-	t.same(sqrt.toString(), '181')
-    t.end();
-});
+  var r = bigint(32769)
+  var sqrt = r.sqrt()
+  var root = r.root(2)
+  t.same(root.toString(), '181')
+  t.same(sqrt.toString(), '181')
+  t.end()
+})

--- a/test/root.js
+++ b/test/root.js
@@ -1,0 +1,11 @@
+var test = require('tap').test;
+var bigint = require('../');
+
+test('sqrt and root', function (t) {
+    var r = bigint(32769)
+	var sqrt = r.sqrt()
+	var root = r.root(2)
+	t.same(root.toString(), '181')
+	t.same(sqrt.toString(), '181')
+    t.end();
+});


### PR DESCRIPTION
I looked at https://github.com/justmoon/node-bignum, but it doesn't support either .sqrt() or root(), which I required.

I think this is a dead project, but in case some fellow traveller finds it useful, this pull request updates node-bigint  to modern (2.2.x) nan bindings. ( Tested with node  4.3.x ).

I didn't spend a lot of time analyzing this work, but it passes all of the tests.  I added some new ones for root() and sqrt(). 

node-bigint
> tap test/*.js

ok test/arithmetic.js ............................. 6691/6691
ok test/bit_length.js ................................... 2/2
ok test/bitwise.js ................................ 4801/4801
ok test/buf.js ........................................ 48/48
ok test/cmp.js .................................... 5293/5293
ok test/create.js ..................................... 20/20
ok test/gcd.js .......................................... 2/2
ok test/invertm.js ...................................... 2/2
ok test/mod.js .......................................... 3/3
ok test/pow.js ........................................ 23/23
ok test/primes.js ..................................... 54/54
ok test/rand.js ................................... 2998/2998
ok test/root.js ......................................... 3/3
ok test/seed.js ....................................... 10/10
ok test/shift.js ........................................ 4/4
total ........................................... 19954/19954

ok

